### PR TITLE
Allow jumping to non-integer cue numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ instance.prototype.actions = function (system) {
 					label: 'Cue Nr',
 					id: 'cue',
 					default: '1',
-					regex: self.REGEX_NUMBER,
+					regex: self.REGEX_FLOAT_OR_INT,
 				},
 			],
 		},


### PR DESCRIPTION
Change regex on jump-to-cue to REGEX_FLOAT_OR_INT